### PR TITLE
Cleanup early work

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
-# dsd-railway
+dsd-railway
+===
 
 A plugin for deploying Django projects to Railway, using django-simple-deploy.
 
 For full documentation, see the documentation for [django-simple-deploy](https://django-simple-deploy.readthedocs.io/en/latest/).
+
+Current status
+---
+
+This plugin is in a pre-1.0 development phase. It has limited functionality at the moment, but should evolve quickly.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Current status
 
 This plugin is in a pre-1.0 development phase. It has limited functionality at the moment, but should evolve quickly.
 
-Automated deployment
+Fully automated deployment
 ---
 
 - Install the [Railway CLI](https://docs.railway.com/guides/cli)
@@ -18,3 +18,5 @@ Automated deployment
 - Install `dsd-railway`: `pip install dsd-railway`
 - Add `django_simple_deploy` to `INSTALLED_APPS`
 - Run `python manage.py deploy --automate-all`.
+
+Your deployed project should appear in a new browser tab.

--- a/README.md
+++ b/README.md
@@ -9,3 +9,12 @@ Current status
 ---
 
 This plugin is in a pre-1.0 development phase. It has limited functionality at the moment, but should evolve quickly.
+
+Automated deployment
+---
+
+- Install the [Railway CLI](https://docs.railway.com/guides/cli)
+- Log in, using `railway login`. You may need to run `railway login --browserless`.
+- Install `dsd-railway`: `pip install dsd-railway`
+- Add `django_simple_deploy` to `INSTALLED_APPS`
+- Run `python manage.py deploy --automate-all`.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,15 @@ Fully automated deployment
 - Run `python manage.py deploy --automate-all`.
 
 Your deployed project should appear in a new browser tab.
+
+Destroying a project
+---
+
+This is mostly for developers, but if you're trying this out and want to destroy a project the following should work:
+
+```sh
+$ export RAILWAY_API_TOKEN=<account-token>
+$ python developer_resources/destroy_project.py <project-id>
+```
+
+Be careful running this command, as it is a destructive action.

--- a/developer_resources/destroy_project.py
+++ b/developer_resources/destroy_project.py
@@ -1,0 +1,37 @@
+"""Destroy a project on Railway."""
+
+import sys
+import os
+from pprint import pprint
+
+import requests
+
+
+project_id = sys.argv[1]
+
+print(f"Destroying project: {project_id}")
+
+confirm = input("\nDestroy project? (y/n): ")
+if confirm.lower() not in ("y", "yes"):
+    sys.exit()
+
+railway_token = os.environ.get("RAILWAY_API_TOKEN", None)
+print(railway_token)
+if not railway_token:
+    print("Please set the RAILWAY_API_TOKEN environment variable.")
+    sys.exit()
+
+base_url = "https://backboard.railway.com/graphql/v2"
+headers = {
+    "Authorization": f"Bearer {railway_token}",
+    "Content-Type": "application/json",
+}
+
+payload = {
+    "query": "query { me { name email } }"
+}
+
+r = requests.post(base_url, headers=headers, json=payload, timeout=30)
+data = r.json()
+
+pprint(data)

--- a/developer_resources/destroy_project.py
+++ b/developer_resources/destroy_project.py
@@ -27,8 +27,12 @@ headers = {
     "Content-Type": "application/json",
 }
 
+# payload = {
+#     "query": "query { me { name email } }"
+# }
+
 payload = {
-    "query": "query { me { name email } }"
+    "query": f'mutation projectDelete {{ projectDelete(id: "{project_id}")}}'
 }
 
 r = requests.post(base_url, headers=headers, json=payload, timeout=30)

--- a/developer_resources/destroy_project.py
+++ b/developer_resources/destroy_project.py
@@ -1,6 +1,10 @@
 """Destroy a project on Railway.
 
 RAILWAY_API_TOKEN should be an account token, not a workspace token.
+
+Usage:
+  $ export RAILWAY_API_TOKEN=<account-token>
+  $ python developer_resources/destroy_project.py <project-id>
 """
 
 import sys

--- a/developer_resources/destroy_project.py
+++ b/developer_resources/destroy_project.py
@@ -1,4 +1,7 @@
-"""Destroy a project on Railway."""
+"""Destroy a project on Railway.
+
+RAILWAY_API_TOKEN should be an account token, not a workspace token.
+"""
 
 import sys
 import os

--- a/developer_resources/destroy_project.py
+++ b/developer_resources/destroy_project.py
@@ -34,10 +34,6 @@ headers = {
     "Content-Type": "application/json",
 }
 
-# payload = {
-#     "query": "query { me { name email } }"
-# }
-
 payload = {
     "query": f'mutation projectDelete {{ projectDelete(id: "{project_id}")}}'
 }

--- a/dsd_railway/deploy_messages.py
+++ b/dsd_railway/deploy_messages.py
@@ -6,8 +6,6 @@ from textwrap import dedent
 
 from django.conf import settings
 
-from .plugin_config import plugin_config
-
 
 confirm_automate_all = """
 The --automate-all flag means django-simple-deploy will:
@@ -77,7 +75,7 @@ def success_msg(log_output=""):
     return msg
 
 
-def success_msg_automate_all(deployed_url):
+def success_msg_automate_all(deployed_url, project_id):
     """Success message, when using --automate-all."""
 
     msg = dedent(
@@ -90,7 +88,7 @@ def success_msg_automate_all(deployed_url):
           refresh the tab. It sometimes takes a few minutes for the
           server to be ready.
         - You can also visit your project at {deployed_url}
-        - Project ID: {plugin_config.project_id}
+        - Project ID: {project_id}
 
         If you make further changes and want to push them to Railway,
         commit your changes and then run `...`.

--- a/dsd_railway/deploy_messages.py
+++ b/dsd_railway/deploy_messages.py
@@ -6,6 +6,8 @@ from textwrap import dedent
 
 from django.conf import settings
 
+from .plugin_config import plugin_config
+
 
 confirm_automate_all = """
 The --automate-all flag means django-simple-deploy will:
@@ -88,6 +90,7 @@ def success_msg_automate_all(deployed_url):
           refresh the tab. It sometimes takes a few minutes for the
           server to be ready.
         - You can also visit your project at {deployed_url}
+        - Project ID: {plugin_config.project_id}
 
         If you make further changes and want to push them to Railway,
         commit your changes and then run `...`.

--- a/dsd_railway/platform_deployer.py
+++ b/dsd_railway/platform_deployer.py
@@ -70,7 +70,9 @@ class PlatformDeployer:
         Raises:
             DSDCommandError: If we find any reason deployment won't work.
         """
-        pass
+        # Use local project name for deployed project, if no custom name passed.
+        if not dsd_config.deployed_project_name:
+            dsd_config.deployed_project_name = dsd_config.local_project_name
 
     def _prep_automate_all(self):
         """Take any further actions needed if using automate_all."""
@@ -151,13 +153,13 @@ class PlatformDeployer:
         self._set_env_vars()
 
         # Redeploy.
-        cmd = "railway redeploy --service blog --yes"
+        cmd = f"railway redeploy --service {dsd_config.deployed_project_name} --yes"
         output = plugin_utils.run_quick_command(cmd)
         plugin_utils.write_output(output)
 
         # Generate a Railway domain.
         msg = "  Generating a Railway domain..."
-        cmd = "railway domain --port 8080 --service blog --json"
+        cmd = f"railway domain --port 8080 --service {dsd_config.deployed_project_name} --json"
         output = plugin_utils.run_quick_command(cmd)
 
         output_json = json.loads(output.stdout.decode())
@@ -199,6 +201,6 @@ class PlatformDeployer:
             '--set "PGPORT=${{Postgres.PGPORT}}"',
         ]
 
-        cmd = f"railway variables {' '.join(env_vars)} --service blog"
+        cmd = f"railway variables {' '.join(env_vars)} --service {dsd_config.deployed_project_name}"
         output = plugin_utils.run_quick_command(cmd)
         plugin_utils.write_output(output)

--- a/dsd_railway/platform_deployer.py
+++ b/dsd_railway/platform_deployer.py
@@ -180,6 +180,18 @@ class PlatformDeployer:
         msg = f"  Waiting {pause}s for deployment to finish..."
         plugin_utils.write_output(msg)
 
+        # Wait for a 200 response.
+        pause = 10
+        timeout = 300
+        for _ in range(int(timeout/pause)):
+            msg = "  Checking if deployment is ready..."
+            plugin_utils.write_output(msg)
+            r = requests.get(self.deployed_url)
+            if r.status_code == 200:
+                break
+
+            time.sleep(pause)
+
         webbrowser.open(self.deployed_url)
 
         msg = f"  If you get an error page, refresh the browser in a minute or two."

--- a/dsd_railway/platform_deployer.py
+++ b/dsd_railway/platform_deployer.py
@@ -126,7 +126,7 @@ class PlatformDeployer:
 
         # Initialize empty project on Railway.
         plugin_utils.write_output("  Initializing empty project on Railway...")
-        cmd = "railway init"
+        cmd = f"railway init --name {dsd_config.deployed_project_name}"
         plugin_utils.run_slow_command(cmd)
 
         # Deploy the project.

--- a/dsd_railway/platform_deployer.py
+++ b/dsd_railway/platform_deployer.py
@@ -159,11 +159,21 @@ class PlatformDeployer:
 
         # Generate a Railway domain.
         msg = "  Generating a Railway domain..."
+        plugin_utils.write_output(msg)
         cmd = f"railway domain --port 8080 --service {dsd_config.deployed_project_name} --json"
         output = plugin_utils.run_quick_command(cmd)
 
         output_json = json.loads(output.stdout.decode())
         self.deployed_url = output_json["domain"]
+
+        # Get project ID.
+        msg = "  Getting project ID..."
+        plugin_utils.write_output(msg)
+        cmd = "railway status --json"
+        output = plugin_utils.run_quick_command(cmd)
+
+        output_json = json.loads(output.stdout.decode())
+        plugin_config.project_id = output_json["id"]
 
         # Wait {pause} before opening.
         pause = 20

--- a/dsd_railway/platform_deployer.py
+++ b/dsd_railway/platform_deployer.py
@@ -204,7 +204,7 @@ class PlatformDeployer:
         Describe ongoing approach of commit, push, migrate.
         """
         if dsd_config.automate_all:
-            msg = platform_msgs.success_msg_automate_all(self.deployed_url)
+            msg = platform_msgs.success_msg_automate_all(self.deployed_url, plugin_config.project_id)
         else:
             msg = platform_msgs.success_msg(log_output=dsd_config.log_output)
         plugin_utils.write_output(msg)

--- a/dsd_railway/templates/settings.py
+++ b/dsd_railway/templates/settings.py
@@ -5,7 +5,7 @@ import os
 
 if os.environ.get("RAILWAY_PROJECT_NAME", ""):
     DEBUG = False
-    
+
     # Configure a Postgres db.
     DATABASES = {
         'default': {
@@ -17,11 +17,6 @@ if os.environ.get("RAILWAY_PROJECT_NAME", ""):
             'PORT': os.environ.get("PGPORT", ""),
         }
     }
-
-    # Helpful for development work.
-    print("\n\n***** ----- *****\n")
-    print(DATABASES)
-    print("\n***** ----- *****\n\n")
 
     # Static files config.
     STATIC_URL = 'static/'

--- a/tmp_docs/resources.md
+++ b/tmp_docs/resources.md
@@ -1,0 +1,12 @@
+Resources
+===
+
+- [ ] [Django on Railway](https://docs.railway.com/guides/django#deploy-from-the-cli), focused on CLI approach.
+- [ ] [community forum](https://station.railway.com)
+- [ ] [Volumes](https://docs.railway.com/overview/the-basics#volumes) (for supporting SQLite)
+- [ ] [The Basics](https://docs.railway.com/overview/the-basics#service-variables)
+- [ ] [Using the CLI](https://docs.railway.com/guides/cli#add-database-service)
+- [ ] [Docs home](https://docs.railway.com)
+- [ ] [CLI Reference](https://docs.railway.com/reference/cli-api#service)
+- [ ] [Quick Start Tutorial](https://docs.railway.com/quick-start) (general platform doc, not Django-specific)
+- [ ] [Pricing](https://railway.com/pricing)


### PR DESCRIPTION
Use local project name instead of hard coded blog name. Simple readme. Temp docs/ dir. Poll for an active project before opening in browser. Script for destroying project by project ID.