### PR TITLE
Write initial e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,18 @@ Configuration-only deployment
 ---
 
 - Install the [Railway CLI](https://docs.railway.com/guides/cli)
-- Log in, using `railway login`. You may need to run `railway login --browserless`.
-- Install `dsd-railway`: `pip install dsd-railway`
-- Add `django_simple_deploy` to `INSTALLED_APPS`
-- Choose a name for your deployed project, and run `python manage.py deploy --deployed-project-name <project-name>`
-- Review and then commit changes.
+- Choose a name for your deployed project, and use it everywhere you see `<project-name>` Run the following commands:
+```sh
+$ railway login # May need to use `railway login --browserless`
+$ pip install dsd-railway
+# Add `django_simple_deploy` to `INSTALLED_APPS`
+$ python manage.py deploy --deployed-project-name <project-name>
+$ git status
+# Review changes
+$ git add .
+$ git commit -m "Configured for deployment to Railway."
+```
+
 - Run the following. (You'll see a bunch of errors after `railway up`. Those errors will go away after creating the database. This is Railway's [recommended approach](https://docs.railway.com/guides/django#deploy-from-the-cli)!)
 ```sh
 $ railway init --name <project-name>

--- a/README.md
+++ b/README.md
@@ -38,11 +38,16 @@ $ railway variables \
     --set 'PGHOST=${{Postgres.PGHOST}}' \
     --set 'PGPORT=${{Postgres.PGPORT}}' \
     --service <project-name>
-$ railway redeploy --service <project-name>
 $ railway domain --port 8080 --service <project-name>
 ```
 
 After this last command, you should see the URL for your project. You may need to wait a few minutes for the deployment to finish.
+
+If your deployment does not seem to work, you can try redeploying it:
+
+```sh
+$ railway redeploy --service <project-name>
+```
 
 Fully automated deployment
 ---

--- a/dsd_railway/platform_deployer.py
+++ b/dsd_railway/platform_deployer.py
@@ -54,6 +54,7 @@ class PlatformDeployer:
 
         # Configure project for deployment to Railway
         self._modify_settings()
+        self._add_railway_toml()
         self._make_static_dir()
         self._add_requirements()
 
@@ -91,6 +92,21 @@ class PlatformDeployer:
             template_path = self.templates_path / "settings.py"
 
         plugin_utils.modify_settings_file(template_path)
+
+    def _add_railway_toml(self):
+        """Add a railway.toml file."""
+        msg = "\nAdding a railway.toml file..."
+        plugin_utils.write_output(msg)
+
+        template_path = self.templates_path / "railway.toml"
+        context = {
+            "local_project_name": dsd_config.local_project_name,
+        }
+        contents = plugin_utils.get_template_string(template_path, context)
+
+        # Write file to project.
+        path = dsd_config.project_root / "railway.toml"
+        plugin_utils.add_file(path, contents)
 
     def _make_static_dir(self):
         """Add a static/ dir if needed."""

--- a/dsd_railway/platform_deployer.py
+++ b/dsd_railway/platform_deployer.py
@@ -97,7 +97,7 @@ class PlatformDeployer:
         msg = "\nAdding a static/ directory and a placeholder text file."
         plugin_utils.write_output(msg)
 
-        path_static = Path("static")
+        path_static = Path("staticfiles")
         plugin_utils.add_dir(path_static)
 
         # Write a placeholder file, to be picked up by Git.

--- a/dsd_railway/platform_deployer.py
+++ b/dsd_railway/platform_deployer.py
@@ -158,10 +158,16 @@ class PlatformDeployer:
         output_json = json.loads(output.stdout.decode())
         plugin_config.project_id = output_json["id"]
 
+        msg = f"  Project ID: {plugin_config.project_id}"
+        plugin_utils.write_output(msg)
+
         # Link project.
         msg = "  Linking project..."
         plugin_utils.write_output(msg)
         cmd = f"railway link --project {plugin_config.project_id} --service {dsd_config.deployed_project_name}"
+
+        output = plugin_utils.run_quick_command(cmd)
+        plugin_utils.write_output(output)
 
         # Deploy the project.
         msg = "  Pushing code to Railway."

--- a/dsd_railway/platform_deployer.py
+++ b/dsd_railway/platform_deployer.py
@@ -192,6 +192,21 @@ class PlatformDeployer:
         # Set env vars.
         self._set_env_vars()
 
+        # Make sure env vars are reading from Postgres values.
+        pause = 10
+        timeout = 60
+        for _ in range(int(timeout/pause)):
+            msg = "  Reading env vars..."
+            plugin_utils.write_output(msg)
+            cmd = f"railway variables --service {dsd_config.deployed_project_name} --json"
+            output = plugin_utils.run_quick_command(cmd)
+            output_json = json.loads(output.stdout.decode())
+            if output_json["PGUSER"] == "postgres":
+                break
+            
+            print(output_json)
+            time.sleep(pause)
+
         # Redeploy.
         cmd = f"railway redeploy --service {dsd_config.deployed_project_name} --yes"
         output = plugin_utils.run_quick_command(cmd)

--- a/dsd_railway/platform_deployer.py
+++ b/dsd_railway/platform_deployer.py
@@ -149,6 +149,20 @@ class PlatformDeployer:
         cmd = f"railway init --name {dsd_config.deployed_project_name}"
         plugin_utils.run_slow_command(cmd)
 
+        # Get project ID.
+        msg = "  Getting project ID..."
+        plugin_utils.write_output(msg)
+        cmd = "railway status --json"
+        output = plugin_utils.run_quick_command(cmd)
+
+        output_json = json.loads(output.stdout.decode())
+        plugin_config.project_id = output_json["id"]
+
+        # Link project.
+        msg = "  Linking project..."
+        plugin_utils.write_output(msg)
+        cmd = f"railway link --project {plugin_config.project_id} --service {dsd_config.deployed_project_name}"
+
         # Deploy the project.
         msg = "  Pushing code to Railway."
         msg += "\n  You'll see a database error, which will be addressed in the next step."
@@ -186,14 +200,14 @@ class PlatformDeployer:
         output_json = json.loads(output.stdout.decode())
         self.deployed_url = output_json["domain"]
 
-        # Get project ID.
-        msg = "  Getting project ID..."
-        plugin_utils.write_output(msg)
-        cmd = "railway status --json"
-        output = plugin_utils.run_quick_command(cmd)
-
-        output_json = json.loads(output.stdout.decode())
-        plugin_config.project_id = output_json["id"]
+        # # Get project ID.
+        # msg = "  Getting project ID..."
+        # plugin_utils.write_output(msg)
+        # cmd = "railway status --json"
+        # output = plugin_utils.run_quick_command(cmd)
+        # 
+        # output_json = json.loads(output.stdout.decode())
+        # plugin_config.project_id = output_json["id"]
 
         # Wait {pause} before opening.
         pause = 20

--- a/dsd_railway/platform_deployer.py
+++ b/dsd_railway/platform_deployer.py
@@ -201,7 +201,7 @@ class PlatformDeployer:
             cmd = f"railway variables --service {dsd_config.deployed_project_name} --json"
             output = plugin_utils.run_quick_command(cmd)
             plugin_utils.write_output(output)
-            
+
             output_json = json.loads(output.stdout.decode())
             if output_json["PGUSER"] == "postgres":
                 break
@@ -279,7 +279,7 @@ class PlatformDeployer:
             '--set "PGPORT=${{Postgres.PGPORT}}"',
         ]
 
-        cmd = f"railway variables {' '.join(env_vars)} --service {dsd_config.deployed_project_name}"
+        cmd = f"railway variables {' '.join(env_vars)} --service {dsd_config.deployed_project_name} --skip-deploys"
         output = plugin_utils.run_quick_command(cmd)
         plugin_utils.write_output(output)
 

--- a/dsd_railway/platform_deployer.py
+++ b/dsd_railway/platform_deployer.py
@@ -200,11 +200,12 @@ class PlatformDeployer:
             plugin_utils.write_output(msg)
             cmd = f"railway variables --service {dsd_config.deployed_project_name} --json"
             output = plugin_utils.run_quick_command(cmd)
+            plugin_utils.write_output(output)
+            
             output_json = json.loads(output.stdout.decode())
             if output_json["PGUSER"] == "postgres":
                 break
             
-            print(output_json)
             time.sleep(pause)
 
         # Redeploy.

--- a/dsd_railway/templates/railway.toml
+++ b/dsd_railway/templates/railway.toml
@@ -1,0 +1,2 @@
+[deploy]
+startCommand = "python manage.py migrate --noinput && python manage.py collectstatic --noinput && gunicorn {{ local_project_name }}.wsgi:application"

--- a/dsd_railway/templates/settings.py
+++ b/dsd_railway/templates/settings.py
@@ -20,9 +20,10 @@ if os.environ.get("RAILWAY_PROJECT_NAME", ""):
 
     # Static files config.
     STATIC_URL = 'static/'
-    STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
+    STATIC_ROOT = BASE_DIR / "staticfiles"
 
-    MIDDLEWARE.insert(1, 'whitenoise.middleware.WhiteNoiseMiddleware')
+    i = MIDDLEWARE.index("django.middleware.security.SecurityMiddleware")
+    MIDDLEWARE.insert(i + 1, "whitenoise.middleware.WhiteNoiseMiddleware")
 
     # Allowed hosts, CSRF.
     ALLOWED_HOSTS = [".up.railway.app"]

--- a/dsd_railway/templates/settings.py
+++ b/dsd_railway/templates/settings.py
@@ -19,9 +19,8 @@ if os.environ.get("RAILWAY_PROJECT_NAME", ""):
     }
 
     # Static files config.
-    STATIC_URL = '/static/'
+    STATIC_URL = 'static/'
     STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
-    STATICFILES_DIRS = [os.path.join(BASE_DIR, "static")]
 
     MIDDLEWARE.insert(1, 'whitenoise.middleware.WhiteNoiseMiddleware')
 

--- a/dsd_railway/templates/settings.py
+++ b/dsd_railway/templates/settings.py
@@ -19,7 +19,7 @@ if os.environ.get("RAILWAY_PROJECT_NAME", ""):
     }
 
     # Static files config.
-    STATIC_URL = 'static/'
+    STATIC_URL = '/static/'
     STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
     STATICFILES_DIRS = [os.path.join(BASE_DIR, "static")]
 

--- a/dsd_railway/templates/settings_wagtail.py
+++ b/dsd_railway/templates/settings_wagtail.py
@@ -18,9 +18,8 @@ DATABASES = {
 }
 
 # Static files config.
-STATIC_URL = '/static/'
+STATIC_URL = 'static/'
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
-STATICFILES_DIRS = [os.path.join(BASE_DIR, "static")]
 
 MIDDLEWARE.insert(1, 'whitenoise.middleware.WhiteNoiseMiddleware')
 

--- a/dsd_railway/templates/settings_wagtail.py
+++ b/dsd_railway/templates/settings_wagtail.py
@@ -18,7 +18,7 @@ DATABASES = {
 }
 
 # Static files config.
-STATIC_URL = 'static/'
+STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 STATICFILES_DIRS = [os.path.join(BASE_DIR, "static")]
 

--- a/tests/e2e_tests/test_deployment.py
+++ b/tests/e2e_tests/test_deployment.py
@@ -131,11 +131,19 @@ def test_deployment(tmp_project, cli_options, request):
     
     # Get URL and project ID from an automated deployment.
     if cli_options.automate_all:
+        # # Get project ID.
+        # cmd = "railway status --json"
+        # output = make_sp_call(cmd, capture_output=True).stdout.decode()
+        # output_json = json.loads(output)
+        # project_id = output_json["id"]
+        # request.config.cache.set("project_id", project_id)
+
+        breakpoint()
         # Get project ID.
-        cmd = "railway status --json"
+        cmd = f"railway variables --service {app_name} --json"
         output = make_sp_call(cmd, capture_output=True).stdout.decode()
         output_json = json.loads(output)
-        project_id = output_json["id"]
+        project_id = output_json["RAILWAY_PROJECT_ID"]
         request.config.cache.set("project_id", project_id)
 
         # Get URL

--- a/tests/e2e_tests/test_deployment.py
+++ b/tests/e2e_tests/test_deployment.py
@@ -56,10 +56,18 @@ def test_deployment(tmp_project, cli_options, request):
         make_sp_call(cmd)
 
         # Get project ID.
-        cmd = "railway status --json"
+        # cmd = "railway status --json"
+        # output = make_sp_call(cmd, capture_output=True).stdout.decode()
+        # output_json = json.loads(output)
+        # project_id = output_json["id"]
+        # request.config.cache.set("project_id", project_id)
+
+        breakpoint()
+        # Get project ID.
+        cmd = f"railway variables --service {app_name} --json"
         output = make_sp_call(cmd, capture_output=True).stdout.decode()
         output_json = json.loads(output)
-        project_id = output_json["id"]
+        project_id = output_json["RAILWAY_PROJECT_ID"]
         request.config.cache.set("project_id", project_id)
 
         # Link project.

--- a/tests/e2e_tests/test_deployment.py
+++ b/tests/e2e_tests/test_deployment.py
@@ -101,22 +101,28 @@ def test_deployment(tmp_project, cli_options, request):
     project_id = output_json["id"]
     request.config.cache.set("project_id", project_id)
     
-    # Note: ***** Remove this line, or your test will always report as passed! *****
-    remote_functionality_passed = True
+    # Get URL from an automated deployment.
+    if cli_options.automate_all:
+        # cmd = f"railway domain --service {app_name}"
+        # output = make_sp_call(cmd, capture_output=True).stdout.decode()
+        # project_url = "https://" + output.split("https://")[-1].strip()
 
+        breakpoint()
+        cmd = f"railway variables --service {app_name} --json"
+        output = make_sp_call(cmd, capture_output=True).stdout.decode()
+        output_json = json.loads(output)
+        project_url = f"https://{output_json["RAILWAY_PUBLIC_DOMAIN"]}
+    
     # Remote functionality test often fails if run too quickly after deployment.
     print("\nPausing 10s to let deployment finish...")
     time.sleep(10)
 
-    # Note: Uncomment this section once your deployment is successful, and 
-    #   project_url is set in the above section.
-    # 
     # Test functionality of both deployed app, and local project.
     #   We want to make sure the deployment works, but also make sure we haven't
     #   affected functionality of the local project using the development server.
-    # remote_functionality_passed = it_utils.check_deployed_app_functionality(
-    #     python_cmd, project_url
-    # )
+    remote_functionality_passed = it_utils.check_deployed_app_functionality(
+        python_cmd, project_url
+    )
     local_functionality_passed = it_utils.check_local_app_functionality(python_cmd)
     log_check_passed = platform_utils.check_log(tmp_project)
 

--- a/tests/e2e_tests/test_deployment.py
+++ b/tests/e2e_tests/test_deployment.py
@@ -56,18 +56,10 @@ def test_deployment(tmp_project, cli_options, request):
         make_sp_call(cmd)
 
         # Get project ID.
-        # cmd = "railway status --json"
-        # output = make_sp_call(cmd, capture_output=True).stdout.decode()
-        # output_json = json.loads(output)
-        # project_id = output_json["id"]
-        # request.config.cache.set("project_id", project_id)
-
-        breakpoint()
-        # Get project ID.
-        cmd = f"railway variables --service {app_name} --json"
+        cmd = "railway status --json"
         output = make_sp_call(cmd, capture_output=True).stdout.decode()
         output_json = json.loads(output)
-        project_id = output_json["RAILWAY_PROJECT_ID"]
+        project_id = output_json["id"]
         request.config.cache.set("project_id", project_id)
 
         # Link project.
@@ -131,19 +123,11 @@ def test_deployment(tmp_project, cli_options, request):
     
     # Get URL and project ID from an automated deployment.
     if cli_options.automate_all:
-        # # Get project ID.
-        # cmd = "railway status --json"
-        # output = make_sp_call(cmd, capture_output=True).stdout.decode()
-        # output_json = json.loads(output)
-        # project_id = output_json["id"]
-        # request.config.cache.set("project_id", project_id)
-
-        breakpoint()
         # Get project ID.
-        cmd = f"railway variables --service {app_name} --json"
+        cmd = "railway status --json"
         output = make_sp_call(cmd, capture_output=True).stdout.decode()
         output_json = json.loads(output)
-        project_id = output_json["RAILWAY_PROJECT_ID"]
+        project_id = output_json["id"]
         request.config.cache.set("project_id", project_id)
 
         # Get URL

--- a/tests/e2e_tests/test_deployment.py
+++ b/tests/e2e_tests/test_deployment.py
@@ -63,7 +63,7 @@ def test_deployment(tmp_project, cli_options, request):
         request.config.cache.set("project_id", project_id)
 
         # Link project.
-        cmd = f"railway link --project {plugin_config.project_id} --service {dsd_config.deployed_project_name}"
+        cmd = f"railway link --project {project_id} --service {app_name}"
         make_sp_call(cmd)
 
         cmd = "railway up"

--- a/tests/e2e_tests/test_deployment.py
+++ b/tests/e2e_tests/test_deployment.py
@@ -70,7 +70,7 @@ def test_deployment(tmp_project, cli_options, request):
         cmd = f"railway variables {' '.join(env_vars)} --service {app_name}"
         make_sp_call(cmd)
 
-        cmd = f"railway redeploy --service {app_name}"
+        cmd = f"railway redeploy --service {app_name} --yes"
         make_sp_call(cmd)
 
         cmd = f"railway domain --port 8080 --service {app_name} --json"

--- a/tests/e2e_tests/test_deployment.py
+++ b/tests/e2e_tests/test_deployment.py
@@ -103,11 +103,6 @@ def test_deployment(tmp_project, cli_options, request):
     
     # Get URL from an automated deployment.
     if cli_options.automate_all:
-        # cmd = f"railway domain --service {app_name}"
-        # output = make_sp_call(cmd, capture_output=True).stdout.decode()
-        # project_url = "https://" + output.split("https://")[-1].strip()
-
-        breakpoint()
         cmd = f"railway variables --service {app_name} --json"
         output = make_sp_call(cmd, capture_output=True).stdout.decode()
         output_json = json.loads(output)

--- a/tests/e2e_tests/test_deployment.py
+++ b/tests/e2e_tests/test_deployment.py
@@ -55,6 +55,17 @@ def test_deployment(tmp_project, cli_options, request):
         cmd = f"railway init --name {app_name}"
         make_sp_call(cmd)
 
+        # Get project ID.
+        cmd = "railway status --json"
+        output = make_sp_call(cmd, capture_output=True).stdout.decode()
+        output_json = json.loads(output)
+        project_id = output_json["id"]
+        request.config.cache.set("project_id", project_id)
+
+        # Link project.
+        cmd = f"railway link --project {plugin_config.project_id} --service {dsd_config.deployed_project_name}"
+        make_sp_call(cmd)
+
         cmd = "railway up"
         make_sp_call(cmd)
 
@@ -93,16 +104,17 @@ def test_deployment(tmp_project, cli_options, request):
             time.sleep(pause)
 
         webbrowser.open(project_url)
-
-    # Get project ID.
-    cmd = "railway status --json"
-    output = make_sp_call(cmd, capture_output=True).stdout.decode()
-    output_json = json.loads(output)
-    project_id = output_json["id"]
-    request.config.cache.set("project_id", project_id)
     
-    # Get URL from an automated deployment.
+    # Get URL and project ID from an automated deployment.
     if cli_options.automate_all:
+        # Get project ID.
+        cmd = "railway status --json"
+        output = make_sp_call(cmd, capture_output=True).stdout.decode()
+        output_json = json.loads(output)
+        project_id = output_json["id"]
+        request.config.cache.set("project_id", project_id)
+
+        # Get URL
         cmd = f"railway variables --service {app_name} --json"
         output = make_sp_call(cmd, capture_output=True).stdout.decode()
         output_json = json.loads(output)

--- a/tests/e2e_tests/test_deployment.py
+++ b/tests/e2e_tests/test_deployment.py
@@ -98,8 +98,8 @@ def test_deployment(tmp_project, cli_options, request):
             time.sleep(pause)
 
 
-        cmd = f"railway redeploy --service {app_name} --yes"
-        make_sp_call(cmd)
+        # cmd = f"railway redeploy --service {app_name} --yes"
+        # make_sp_call(cmd)
 
         cmd = f"railway domain --port 8080 --service {app_name} --json"
         output = make_sp_call(cmd, capture_output=True)

--- a/tests/e2e_tests/test_deployment.py
+++ b/tests/e2e_tests/test_deployment.py
@@ -3,6 +3,7 @@ import json
 import webbrowser
 
 import pytest
+import requests
 
 from tests.e2e_tests.utils import it_helper_functions as it_utils
 from . import utils as platform_utils

--- a/tests/e2e_tests/test_deployment.py
+++ b/tests/e2e_tests/test_deployment.py
@@ -78,6 +78,19 @@ def test_deployment(tmp_project, cli_options, request):
 
         output_json = json.loads(output.stdout.decode())
         project_url = output_json["domain"]
+
+        # Wait for a 200 response.
+        pause = 10
+        timeout = 300
+        for _ in range(int(timeout/pause)):
+            msg = "  Checking if deployment is ready..."
+            print(msg)
+            r = requests.get(project_url)
+            if r.status_code == 200:
+                break
+
+            time.sleep(pause)
+
         webbrowser.open(project_url)
 
     # Get project ID.

--- a/tests/e2e_tests/test_deployment.py
+++ b/tests/e2e_tests/test_deployment.py
@@ -82,6 +82,22 @@ def test_deployment(tmp_project, cli_options, request):
         cmd = f"railway variables {' '.join(env_vars)} --service {app_name}"
         make_sp_call(cmd)
 
+        # Make sure env vars are reading from Postgres values.
+        pause = 10
+        timeout = 60
+        for _ in range(int(timeout/pause)):
+            msg = "  Reading env vars..."
+            print(msg)
+            cmd = f"railway variables --service {app_name} --json"
+            output = make_sp_call(cmd, capture_output=True)
+            output_json = json.loads(output.stdout.decode())
+            if output_json["PGUSER"] == "postgres":
+                break
+            
+            print(output_json)
+            time.sleep(pause)
+
+
         cmd = f"railway redeploy --service {app_name} --yes"
         make_sp_call(cmd)
 

--- a/tests/e2e_tests/test_deployment.py
+++ b/tests/e2e_tests/test_deployment.py
@@ -111,7 +111,7 @@ def test_deployment(tmp_project, cli_options, request):
         cmd = f"railway variables --service {app_name} --json"
         output = make_sp_call(cmd, capture_output=True).stdout.decode()
         output_json = json.loads(output)
-        project_url = f"https://{output_json["RAILWAY_PUBLIC_DOMAIN"]}
+        project_url = f"https://{output_json['RAILWAY_PUBLIC_DOMAIN']}"
     
     # Remote functionality test often fails if run too quickly after deployment.
     print("\nPausing 10s to let deployment finish...")

--- a/tests/e2e_tests/utils.py
+++ b/tests/e2e_tests/utils.py
@@ -6,6 +6,7 @@ Some Fly.io functions are included as an example.
 import re, time
 import json
 import os
+import pprint
 
 import requests
 

--- a/tests/e2e_tests/utils.py
+++ b/tests/e2e_tests/utils.py
@@ -6,6 +6,8 @@ Some Fly.io functions are included as an example.
 import re, time
 import json
 
+import requests
+
 from tests.e2e_tests.utils.it_helper_functions import make_sp_call
 
 
@@ -91,17 +93,31 @@ def check_log(tmp_proj_dir):
     return True
 
 
-# def destroy_project(request):
-#     """Destroy the deployed project, and all remote resources."""
-#     print("\nCleaning up:")
+def destroy_project(request):
+    """Destroy the deployed project, and all remote resources."""
+    print("\nCleaning up:")
 
-#     app_name = request.config.cache.get("app_name", None)
-#     if not app_name:
-#         print("  No app name found; can't destroy any remote resources.")
-#         return None
+    project_id = request.config.cache.get("project_id", None)
+    if not project_id:
+        print("  No project id found; can't destroy any remote resources.")
+        return None
 
-#     print("  Destroying Fly.io project...")
-#     make_sp_call(f"fly apps destroy -y {app_name}")
+    print("  Destroying Railway project...")
+    railway_token = os.environ.get("RAILWAY_API_TOKEN", None)
+    if not railway_token:
+        print("Please set the RAILWAY_API_TOKEN environment variable.")
+        return
 
-#     print("  Destroying Fly.io database...")
-#     make_sp_call(f"fly apps destroy -y {app_name}-db")
+    base_url = "https://backboard.railway.com/graphql/v2"
+    headers = {
+        "Authorization": f"Bearer {railway_token}",
+        "Content-Type": "application/json",
+    }
+
+    payload = {
+        "query": f'mutation projectDelete {{ projectDelete(id: "{project_id}")}}'
+    }
+
+    r = requests.post(base_url, headers=headers, json=payload, timeout=30)
+    data = r.json()
+    pprint(data)

--- a/tests/e2e_tests/utils.py
+++ b/tests/e2e_tests/utils.py
@@ -5,6 +5,7 @@ Some Fly.io functions are included as an example.
 
 import re, time
 import json
+import os
 
 import requests
 

--- a/tests/e2e_tests/utils.py
+++ b/tests/e2e_tests/utils.py
@@ -6,7 +6,7 @@ Some Fly.io functions are included as an example.
 import re, time
 import json
 import os
-import pprint
+from pprint import pprint
 
 import requests
 
@@ -84,7 +84,7 @@ def check_log(tmp_proj_dir):
     if not path.exists():
         return False
 
-    log_files = list(path.glob("simple_deploy_*.log"))
+    log_files = list(path.glob("dsd_*.log"))
     if not log_files:
         return False
 

--- a/tests/e2e_tests/utils.py
+++ b/tests/e2e_tests/utils.py
@@ -80,7 +80,7 @@ def check_log(tmp_proj_dir):
 
     Checks that log file exists, and that DATABASE_URL is not logged.
     """
-    path = tmp_proj_dir / "simple_deploy_logs"
+    path = tmp_proj_dir / "dsd_logs"
     if not path.exists():
         return False
 


### PR DESCRIPTION
Implements e2e tests for configuration-only and fully automated modes. Fixes issue with admin static files. Uses railway.toml file to run collectstatic on each deploy. Clarified documentation. Links project after init. Make sure env vars are being set before redeploying. 